### PR TITLE
Throw an exit code if image file not found or wrong color hex code

### DIFF
--- a/change-gdm-background
+++ b/change-gdm-background
@@ -211,5 +211,6 @@ else
     echo 'Please, submit a .jpg or .png image file or a valid hex code.'
     echo 'Usage: sudo ./ubuntu-20.04-change-gdm-background /path/to/image.*g'
     echo 'Usage: sudo ./ubuntu-20.04-change-gdm-background \#yourhexcode'
+    exit 2
 
 fi


### PR DESCRIPTION
If you pass a wrong param ther is no error code.
That leads to this type of error:

```bash
# sudo bash -c './change-gdm-background' && echo "DONE" || echo "ERROR"
Image file not found or wrong color hex code.
Please, submit a .jpg or .png image file or a valid hex code.
Usage: sudo ./ubuntu-20.04-change-gdm-background /path/to/image.*g
Usage: sudo ./ubuntu-20.04-change-gdm-background \#yourhexcode
DONE
```